### PR TITLE
Add missing options on docker.Run

### DIFF
--- a/run.go
+++ b/run.go
@@ -33,8 +33,9 @@ func (dock *Docker) Run(options *RunOptions) (*Container, error) {
 		return nil, err
 	}
 
-	err = dock.client.StartContainer(container.ID, &docker.HostConfig{
-		Binds:           options.VolumeBinds,
+	err = dock.Start(&StartOptions{
+		ID:              container.ID,
+		VolumeBinds:     options.VolumeBinds,
 		Links:           options.Links,
 		PublishAllPorts: options.PublishAllPorts,
 		PortBindings:    options.PortBindings,

--- a/start.go
+++ b/start.go
@@ -5,9 +5,18 @@ import (
 )
 
 type StartOptions struct {
-	ID string
+	ID              string
+	VolumeBinds     []string
+	Links           []string
+	PublishAllPorts bool
+	PortBindings    map[docker.Port][]docker.PortBinding
 }
 
 func (dock *Docker) Start(options *StartOptions) error {
-	return dock.client.StartContainer(options.ID, &docker.HostConfig{})
+	return dock.client.StartContainer(options.ID, &docker.HostConfig{
+		Binds:           options.VolumeBinds,
+		Links:           options.Links,
+		PublishAllPorts: options.PublishAllPorts,
+		PortBindings:    options.PortBindings,
+	})
 }


### PR DESCRIPTION
We can now bind volumes and ports on existing container!