### PR TITLE
Fix a bug where LogConfig was not passed to the docker client library

### DIFF
--- a/start.go
+++ b/start.go
@@ -19,5 +19,6 @@ func (dock *Docker) Start(options *StartOptions) error {
 		Links:           options.Links,
 		PublishAllPorts: options.PublishAllPorts,
 		PortBindings:    options.PortBindings,
+		LogConfig:       options.LogConfig,
 	})
 }


### PR DESCRIPTION
Was broken after yesterday merge conflict between #8 and #9