### PR TITLE
Fix TLS issue with the latest fsouza library version

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1,11 +1,7 @@
 package dockercommand
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -17,35 +13,21 @@ type Docker struct {
 
 func NewDocker(endpoint string) (*Docker, error) {
 	endpoint = resolveDockerEndpoint(endpoint)
-	client, err := docker.NewClient(resolveDockerEndpoint(endpoint))
+
+	if len(os.Getenv("DOCKER_CERT_PATH")) != 0 {
+		client, err := docker.NewTLSClient(endpoint, os.Getenv("DOCKER_CERT_PATH")+"/cert.pem",
+			os.Getenv("DOCKER_CERT_PATH")+"/key.pem",
+			os.Getenv("DOCKER_CERT_PATH")+"/ca.pem")
+		if err != nil {
+			log.Fatal(err)
+		}
+		return &Docker{&FsouzaClient{client}}, nil
+	}
+
+	client, err := docker.NewClient(endpoint)
 	if err != nil {
 		return nil, err
 	}
-
-	if len(os.Getenv("DOCKER_CERT_PATH")) != 0 {
-		cert, err := tls.LoadX509KeyPair(os.Getenv("DOCKER_CERT_PATH")+"/cert.pem", os.Getenv("DOCKER_CERT_PATH")+"/key.pem")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		caCert, err := ioutil.ReadFile(os.Getenv("DOCKER_CERT_PATH") + "/ca.pem")
-		if err != nil {
-			log.Fatal(err)
-		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
-
-		tlsConfig := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      caCertPool,
-		}
-		tlsConfig.BuildNameToCertificate()
-		tr := &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-		client.HTTPClient.Transport = tr
-	}
-
 	return &Docker{&FsouzaClient{client}}, nil
 }
 


### PR DESCRIPTION
The newer version of fsouza docker client sets the transport (thus
overriding the one setup by dockercommand), which breaks when
TSL_VERIFY is set with errors like:

```
$ bzk service status
2015/11/18 23:14:51 Get http://172.16.187.131:2376/containers/json?all=1: malformed HTTP response "\x15\x03\x01\x00\x02\x02"
```

This fix make use of the new TLS-enabled client of the fsouza library