### PR TITLE
Be able to pass in BuildOptions the BuildArgs as a map[string]string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 .vagrant
+
+.idea

--- a/build.go
+++ b/build.go
@@ -16,6 +16,8 @@ type BuildOptions struct {
 	Path string
 	// The repository name
 	Tag string
+	//The Build args
+	BuildArgs map[string]string
 }
 
 func (dock *Docker) Build(options *BuildOptions) error {
@@ -34,11 +36,23 @@ func (dock *Docker) BuildWithLogger(options *BuildOptions, logger *log.Logger) e
 		}
 	}(logsReader)
 
+	buildArgs := make([]docker.BuildArg, len(options.BuildArgs))
+	i := 0
+
+	for k, v := range options.BuildArgs {
+		buildArgs[i] = docker.BuildArg{
+			Name:  k,
+			Value: v,
+		}
+		i++
+	}
+
 	opts := docker.BuildImageOptions{
 		Name:         options.Tag,
 		Dockerfile:   options.Dockerfile,
 		ContextDir:   options.Path,
 		OutputStream: outputbuf,
+		BuildArgs:    buildArgs,
 	}
 	err := dock.client.BuildImage(opts)
 

--- a/build_test.go
+++ b/build_test.go
@@ -21,3 +21,24 @@ func TestDockerBuild(t *testing.T) {
 
 	// TODO clean image
 }
+
+func TestDockerBuildWithBuildArg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	docker, err := NewDocker("")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	err = docker.Build(&BuildOptions{
+		Dockerfile: "Dockerfile_test",
+		Path:       ".",
+		Tag:        "testgodockercommand",
+		BuildArgs: map[string]string{
+			"HTTP_PROXY": "http://10.20.30.2:1234",
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}


### PR DESCRIPTION
The goal is to be able to build new images with --build-arg parameter.